### PR TITLE
Redesing the bot interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Update to protocol version `2.0.0`
+* Redesign the `BotAPI` interface. Only the `tickNotification` method can return a single `request` to be sent to the server.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -44,51 +44,58 @@ interface BotAPI<S> {
     radarScanNotification?: (
       data: RadarScanNotification,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
     registerPlayerResponse?: (
       data: SuccessfulRegisterPlayerResponse | FailedRegisterPlayerResponse,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
     rotatePlayerResponse?: (
       data: SuccessfulRotatePlayerResponse | FailedRotatePlayerResponse,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
     movePlayerResponse?: (
       data: SuccessfulMovePlayerResponse | FailedMovePlayerResponse,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
     shootResponse?: (
       data: SuccessfulShootResponse | FailedShootResponse,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
-		deployMineResponse?: (
+    deployMineResponse?: (
       data: SuccessfulDeployMineResponse | FailedDeployMineResponse,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
-		shotHitNotification?: (
+    hitNotification?: (
       data: PlayerHitNotification,
       state: S
-    ) => { state: S, requests: Request[] }
+    ) => { state: S }
 
-		tickNotification?: (
+    tickNotification?: (
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S, request: Request }
 
-    startGameNotification?: (state: S) => { state: S, requests: Request[] }
+    startGameNotification?: (
+      state: S
+    ) => { state: S }
 
-    joinGameNotification?: (state: S) => { state: S, requests: Request[] }
+    joinGameNotification?: (
+      data: JoinGameNotification,
+      state: S
+    ) => { state: S }
   }
 }
 
 ```
 
 For a list of all the types mentioned in this interface check: [types](./src/types.ts) and [requests](./src/requests.ts). The npm package exports the required type definitions to build a bot in TypeScript.
+
+Notice that you can only return a request to be sent to the server from the `tickNotification` handler.
 
 ### Helpers
 

--- a/src/message-dispatcher.ts
+++ b/src/message-dispatcher.ts
@@ -87,12 +87,10 @@ function deployMine (): DeployMineRequestMessage {
     id: MessageRequestTypes.DeployMine
   }
 
-  // writeMessagesToFile('send', data)
-
   return data
 }
 
-export function messageDispatcher (message: any, bot: BotAPI<any>, context: { botState: any }): { newBotState: any, messages: any[] } {
+export function messageDispatcher<S> (message: any, bot: BotAPI<S>, context: { botState: S }): { newBotState: S, messages: any[] } {
   if (isRegisterPlayerResponseMessage(message)) {
     if (!bot.handlers.registerPlayerResponse) {
       return { newBotState: context.botState, messages: [] }
@@ -111,24 +109,12 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
         throw new Error('invalid response message')
       }
 
-      const { state: newBotState, requests: [request] } = bot.handlers.registerPlayerResponse(
+      const { state: newBotState } = bot.handlers.registerPlayerResponse(
         { success: true, data: message.details },
         context.botState
       )
 
-      // TODO remove this message handling logic
-      const messages = []
-      let responseMessage
-
-      if (request && request.type === RequestTypes.Move) {
-        responseMessage = move(request.data.direction, false)
-      }
-
-      if (responseMessage) {
-        messages.push(responseMessage)
-      }
-
-      return { newBotState, messages }
+      return { newBotState, messages: [] }
     }
   }
 
@@ -151,18 +137,12 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
 
       const { position, tokens } = message.data.component.details
       const requestDetails = message.data.request
-      const { state: newBotState, requests: [request] } = bot.handlers.movePlayerResponse(
+      const { state: newBotState } = bot.handlers.movePlayerResponse(
         { success: true, data: { position, tokens, request: requestDetails } },
         context.botState
       )
-      let messages: RequestMessage[] = []
-      const messageFromRequest = requestToMessage(request)
 
-      if (messageFromRequest) {
-        messages = [messageFromRequest]
-      }
-
-      return { newBotState, messages }
+      return { newBotState, messages: [] }
     }
   }
 
@@ -187,18 +167,12 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
 
     const { rotation, tokens } = message.data.component.details
     const requestDetails = message.data.request
-    const { state: newBotState, requests: [request] } = bot.handlers.rotatePlayerResponse(
+    const { state: newBotState } = bot.handlers.rotatePlayerResponse(
       { success: message.success, data: { rotation, tokens, request: requestDetails } },
       context.botState
     )
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isShootResponseMessage(message)) {
@@ -222,7 +196,7 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
 
     const { tokens } = message.data.component.details
     const requestDetails = message.data.request
-    const { state: newBotState, requests: [request] } = bot.handlers.shootResponse(
+    const { state: newBotState } = bot.handlers.shootResponse(
       {
         success: message.success,
         data: {
@@ -232,14 +206,8 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
       },
       context.botState
     )
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isDeployMineResponseMessage(message)) {
@@ -264,18 +232,12 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
     const { tokens } = message.data.component.details
     const requestDetails = message.data.request
 
-    const { state: newBotState, requests: [request] } = bot.handlers.deployMineResponse(
+    const { state: newBotState } = bot.handlers.deployMineResponse(
       { success: message.success, data: { tokens, request: requestDetails } },
       context.botState
     )
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isRadarScanNotificationMessage(message)) {
@@ -288,15 +250,9 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
     }
 
     const { data } = message
-    const { state: newBotState, requests: [request] } = bot.handlers.radarScanNotification({ data }, context.botState)
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
+    const { state: newBotState } = bot.handlers.radarScanNotification({ data }, context.botState)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isStartGameNotificationMessage(message)) {
@@ -304,15 +260,9 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
       return { newBotState: context.botState, messages: [] }
     }
 
-    const { state: newBotState, requests: [request] } = bot.handlers.startGameNotification(context.botState)
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
+    const { state: newBotState } = bot.handlers.startGameNotification(context.botState)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isJoinGameNotificationMessage(message)) {
@@ -321,15 +271,9 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
     }
 
     const { details } = message
-    const { state: newBotState, requests: [request] } = bot.handlers.joinGameNotification({ data: details }, context.botState)
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
+    const { state: newBotState } = bot.handlers.joinGameNotification({ data: details }, context.botState)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isPlayerHitNotificationMessage(message)) {
@@ -338,15 +282,9 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
     }
 
     const { data } = message
-    const { state: newBotState, requests: [request] } = bot.handlers.hitNotification(data, context.botState)
-    let messages: RequestMessage[] = []
-    const messageFromRequest = requestToMessage(request)
+    const { state: newBotState } = bot.handlers.hitNotification(data, context.botState)
 
-    if (messageFromRequest) {
-      messages = [messageFromRequest]
-    }
-
-    return { newBotState, messages }
+    return { newBotState, messages: [] }
   }
 
   if (isTickNotification(message)) {
@@ -354,7 +292,7 @@ export function messageDispatcher (message: any, bot: BotAPI<any>, context: { bo
       return { newBotState: context.botState, messages: [] }
     }
 
-    const { state: newBotState, requests: [request] } = bot.handlers.tickNotification(context.botState)
+    const { state: newBotState, request } = bot.handlers.tickNotification(context.botState)
     let messages: RequestMessage[] = []
     const messageFromRequest = requestToMessage(request)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export interface Position {
 }
 
 export type Rotation = number
-export type HandlerReturn<S> = { state: S, requests: Request[] }
 
 export interface BotAPI<S> {
   initState?: () => S
@@ -16,50 +15,52 @@ export interface BotAPI<S> {
     radarScanNotification?: (
       data: RadarScanNotification,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     registerPlayerResponse?: (
       data: SuccessfulRegisterPlayerResponse | FailedRegisterPlayerResponse,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     rotatePlayerResponse?: (
       data: SuccessfulRotatePlayerResponse | FailedRotatePlayerResponse,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     movePlayerResponse?: (
       data: SuccessfulMovePlayerResponse | FailedMovePlayerResponse,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     shootResponse?: (
       data: SuccessfulShootResponse | FailedShootResponse,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     deployMineResponse?: (
       data: SuccessfulDeployMineResponse | FailedDeployMineResponse,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     hitNotification?: (
       data: PlayerHitNotification,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
 
     tickNotification?: (
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S, request: Request }
 
     // TODO include handler for destroyed player
 
-    startGameNotification?: (state: S) => HandlerReturn<S>
+    startGameNotification?: (
+      state: S
+    ) => { state: S }
 
     joinGameNotification?: (
       data: JoinGameNotification,
       state: S
-    ) => HandlerReturn<S>
+    ) => { state: S }
   }
 }
 

--- a/test/unit/dispatcher-spec.ts
+++ b/test/unit/dispatcher-spec.ts
@@ -75,7 +75,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        registerPlayerResponse: sinon.stub().returns({ state: {}, requests: [] })
+        registerPlayerResponse: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -91,7 +91,7 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.registerPlayerResponse.returns({ state, requests: [] })
+      bot.handlers.registerPlayerResponse.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
@@ -105,7 +105,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        startGameNotification: sinon.stub().returns({ state: {}, requests: [] })
+        startGameNotification: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -118,18 +118,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.startGameNotification.returns({ state, requests: [] })
+      bot.handlers.startGameNotification.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.startGameNotification.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Join game notification', () => {
@@ -153,7 +146,7 @@ describe('Message dispatcher', () => {
 
     const bot = {
       handlers: {
-        joinGameNotification: sinon.stub().returns({ state: {}, requests: [] })
+        joinGameNotification: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -169,18 +162,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.joinGameNotification.returns({ state, requests: [] })
+      bot.handlers.joinGameNotification.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.joinGameNotification.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Move player response', () => {
@@ -203,7 +189,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        movePlayerResponse: sinon.stub().returns({ state: {}, requests: [] })
+        movePlayerResponse: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -229,18 +215,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.movePlayerResponse.returns({ state, requests: [] })
+      bot.handlers.movePlayerResponse.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.movePlayerResponse.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Rotate player response', () => {
@@ -262,7 +241,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        rotatePlayerResponse: sinon.stub().returns({ state: {}, requests: [] })
+        rotatePlayerResponse: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -287,18 +266,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.rotatePlayerResponse.returns({ state, requests: [] })
+      bot.handlers.rotatePlayerResponse.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.rotatePlayerResponse.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Shoot response', () => {
@@ -319,7 +291,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        shootResponse: sinon.stub().returns({ state: {}, requests: [] })
+        shootResponse: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -343,18 +315,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.shootResponse.returns({ state, requests: [] })
+      bot.handlers.shootResponse.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.shootResponse.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('DeployMine response', () => {
@@ -375,7 +340,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        deployMineResponse: sinon.stub().returns({ state: {}, requests: [] })
+        deployMineResponse: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -399,18 +364,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.deployMineResponse.returns({ state, requests: [] })
+      bot.handlers.deployMineResponse.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.deployMineResponse.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Radar scan notification', () => {
@@ -426,7 +384,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        radarScanNotification: sinon.stub().returns({ state: {}, requests: [] })
+        radarScanNotification: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -442,18 +400,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.radarScanNotification.returns({ state, requests: [] })
+      bot.handlers.radarScanNotification.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.radarScanNotification.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Player hit notification', () => {
@@ -466,7 +417,7 @@ describe('Message dispatcher', () => {
     }
     const bot = {
       handlers: {
-        hitNotification: sinon.stub().returns({ state: {}, requests: [] })
+        hitNotification: sinon.stub().returns({ state: {} })
       }
     }
     const context = { botState: {} }
@@ -482,18 +433,11 @@ describe('Message dispatcher', () => {
 
     it('returns the new state', () => {
       const state = { foo: 'bar' }
-      bot.handlers.hitNotification.returns({ state, requests: [] })
+      bot.handlers.hitNotification.returns({ state })
       const { newBotState } = messageDispatcher(message, bot, context)
 
       expect(newBotState).to.eql(state)
     })
-
-    it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.hitNotification.returns({ state: {}, requests: [request] })
-      const { messages } = messageDispatcher(message, bot, context)
-
-      expect(messages[0]).to.eql(expectedMessage)
-    }))
   })
 
   describe('Tick notification', () => {
@@ -525,7 +469,7 @@ describe('Message dispatcher', () => {
     })
 
     it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
-      bot.handlers.tickNotification.returns({ state: {}, requests: [request] })
+      bot.handlers.tickNotification.returns({ state: {}, request })
       const { messages } = messageDispatcher(message, bot, context)
 
       expect(messages[0]).to.eql(expectedMessage)


### PR DESCRIPTION
Significant changes:

* Remove the array of requests since the server can only take one request
at a time
* To make it easier to reason about the API, only the
`tickNofitication` handler can return a request. All the other methods
can only return a new state.