### PR TITLE
Do not reset the `inFlightRequest` flag when a notification is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2020-04-08
+
+### Fixed
+
+* The message dispatcher was resetting the `inFlighRequest` when a notification was received
+
 ## [5.0.0] - 2020-04-08
 
 ### Changed

--- a/src/message-dispatcher.ts
+++ b/src/message-dispatcher.ts
@@ -261,7 +261,7 @@ export function messageDispatcher<S> (
     const { data } = message
     const { state: newBotState } = bot.handlers.radarScanNotification({ data }, context.botState)
 
-    return { newContext: { botState: newBotState }, messages: [] }
+    return { newContext: { ...context, botState: newBotState }, messages: [] }
   }
 
   if (isStartGameNotificationMessage(message)) {
@@ -271,7 +271,7 @@ export function messageDispatcher<S> (
 
     const { state: newBotState } = bot.handlers.startGameNotification(context.botState)
 
-    return { newContext: { botState: newBotState }, messages: [] }
+    return { newContext: { ...context, botState: newBotState }, messages: [] }
   }
 
   if (isJoinGameNotificationMessage(message)) {
@@ -282,7 +282,7 @@ export function messageDispatcher<S> (
     const { details } = message
     const { state: newBotState } = bot.handlers.joinGameNotification({ data: details }, context.botState)
 
-    return { newContext: { botState: newBotState }, messages: [] }
+    return { newContext: { ...context, botState: newBotState }, messages: [] }
   }
 
   if (isPlayerHitNotificationMessage(message)) {
@@ -293,7 +293,7 @@ export function messageDispatcher<S> (
     const { data } = message
     const { state: newBotState } = bot.handlers.hitNotification(data, context.botState)
 
-    return { newContext: { botState: newBotState }, messages: [] }
+    return { newContext: { ...context, botState: newBotState }, messages: [] }
   }
 
   if (isTickNotification(message)) {

--- a/test/unit/dispatcher-spec.ts
+++ b/test/unit/dispatcher-spec.ts
@@ -129,6 +129,13 @@ describe('Message dispatcher', () => {
 
       expect(newContext.botState).to.eql(state)
     })
+
+    it('does not reset the "inFlightRequest" flag to undefined', () => {
+      const request = shootRequest()
+      const { newContext } = messageDispatcher(message, bot, { ...context, inFlightRequest: request })
+
+      expect(newContext.inFlightRequest).to.eql(request)
+    })
   })
 
   describe('Join game notification', () => {
@@ -173,6 +180,13 @@ describe('Message dispatcher', () => {
       const { newContext } = messageDispatcher(message, bot, context)
 
       expect(newContext.botState).to.eql(state)
+    })
+
+    it('does not reset the "inFlightRequest" flag to undefined', () => {
+      const request = shootRequest()
+      const { newContext } = messageDispatcher(message, bot, { ...context, inFlightRequest: request })
+
+      expect(newContext.inFlightRequest).to.eql(request)
     })
   })
 
@@ -441,6 +455,13 @@ describe('Message dispatcher', () => {
 
       expect(newContext.botState).to.eql(state)
     })
+
+    it('does not reset the "inFlightRequest" flag to undefined', () => {
+      const request = shootRequest()
+      const { newContext } = messageDispatcher(message, bot, { ...context, inFlightRequest: request })
+
+      expect(newContext.inFlightRequest).to.eql(request)
+    })
   })
 
   describe('Player hit notification', () => {
@@ -474,6 +495,13 @@ describe('Message dispatcher', () => {
       const { newContext } = messageDispatcher(message, bot, context)
 
       expect(newContext.botState).to.eql(state)
+    })
+
+    it('does not reset the "inFlightRequest" flag to undefined', () => {
+      const request = shootRequest()
+      const { newContext } = messageDispatcher(message, bot, { ...context, inFlightRequest: request })
+
+      expect(newContext.inFlightRequest).to.eql(request)
     })
   })
 


### PR DESCRIPTION
The message dispatcher was mistakenly resetting the `inFlightRequest`
flag when a notification was received