### PR TITLE
Install Typescript as a prod dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.0.1] - 2020-04-08
+## [5.0.2] - 2020-04-13
+
+### Fixed
+
+* Install `Typescript` as a prod dependency so installs which only have `Typescript` as dev dependency and prune non-prod dependencies can still execute their `Typescript` bots.
+
+## [5.0.1] - 2020-04-12
 
 ### Fixed
 
 * The message dispatcher was resetting the `inFlighRequest` when a notification was received
 
-## [5.0.0] - 2020-04-08
+## [5.0.0] - 2020-04-12
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2754,10 +2754,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
-      "dev": true
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "ts-node": "^8.7.0",
+    "typescript": "^3.8.3",
     "ws": "^7.2.0",
     "yargs": "^15.0.1"
   },
@@ -49,7 +50,6 @@
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^7.0.0",
     "sinon": "^7.5.0",
-    "sinon-chai": "^3.3.0",
-    "typescript": "^3.7.4"
+    "sinon-chai": "^3.3.0"
   }
 }


### PR DESCRIPTION
Without Typescript being installed as a prod dependency, TS bots
couldn't be executed in the dev dependencies had been pruned or if
Typescript was not available in the host repo.

Also, amend the date in previous CHANGELOG entries : (