### PR TITLE
Do not override the inflight request

### DIFF
--- a/src/message-dispatcher.ts
+++ b/src/message-dispatcher.ts
@@ -303,13 +303,19 @@ export function messageDispatcher<S> (
 
     const { state: newBotState, request } = bot.handlers.tickNotification(context.botState, { inFlightRequest: context.inFlightRequest })
     let messages: RequestMessage[] = []
+    let inFlightRequest = context.inFlightRequest
     const messageFromRequest = requestToMessage(request)
+
+    if (request) {
+      inFlightRequest = request
+    }
 
     if (messageFromRequest) {
       messages = [messageFromRequest]
     }
 
-    const newContext: DispatcherContext<S> = { botState: newBotState, inFlightRequest: request }
+
+    const newContext: DispatcherContext<S> = { botState: newBotState, inFlightRequest }
 
     return { newContext, messages }
   }

--- a/test/unit/dispatcher-spec.ts
+++ b/test/unit/dispatcher-spec.ts
@@ -553,6 +553,13 @@ describe('Message dispatcher', () => {
       )
     })
 
+    it('does not override the "inFlightRequest" if the handler returns an undefined "request"', () => {
+      const request = shootRequest()
+      const result = messageDispatcher(message, bot, { ...context, inFlightRequest: request })
+
+      expect(result.newContext.inFlightRequest).to.eql(request)
+    })
+
     it('returns the request transformed as a message', generateRequestMessage((request, expectedMessage) => {
       tickNotification.returns({ state: {}, request })
       const { messages } = messageDispatcher(message, bot, context)


### PR DESCRIPTION
If the `tickNotification` handler does not return a `request` the
dispatcher should not override the current `inFlightRequest` if it was
set